### PR TITLE
Lock sqlite gem version to 1.3

### DIFF
--- a/solidus_graphql_api.gemspec
+++ b/solidus_graphql_api.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   #s.add_development_dependency 'rubocop-rails', '1.4.0'
   #s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end


### PR DESCRIPTION
On February 04, 2019 sqlite3 1.4.0 has been released. This version breaks ActiveRecord 5.2.2 SQLite adapter, which requires sqlite3 ~> 1.3.6: https://github.com/rails/rails/blob/v5.2.2/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L12