### PR TITLE
Add graphiql-rails gem to development dependencies

### DIFF
--- a/solidus_graphql_api.gemspec
+++ b/solidus_graphql_api.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', '>= 2.7.0'
   s.add_dependency 'graphql', "~> 1.8.10"
 
+  s.add_development_dependency 'graphiql-rails'
   s.add_development_dependency 'database_cleaner'
   #s.add_development_dependency 'byebug'
   #s.add_development_dependency 'ffaker'


### PR DESCRIPTION
`graphiql-rails` gem is pretty essential in order to debug GraphQL queries, so it should be a good idea to add it to the development dependencies.