### PR TITLE
Add Gemfile to the test app

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,10 @@ RuboCop::RakeTask.new
 
 task default: %i(first_run rubocop spec)
 
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
 task :first_run do
   if Dir['spec/dummy'].empty?
     Rake::Task[:test_app].invoke
@@ -23,4 +27,19 @@ desc 'Shorthand to generate dummy app for testing the extension with defaults'
 task :test_app do
   ENV['LIB_NAME'] = 'solidus_graphql_api'
   Rake::Task['extension:test_app'].invoke
+
+  Bundler.with_clean_env do
+    system! 'bundle init'
+
+    File.write 'Gemfile', <<~RUBY, mode: 'a'
+      gem 'rails'
+      gem 'sqlite3', '~> 1.3.6'
+      gem 'solidus'
+      gem 'solidus_auth_devise'
+      gem 'solidus_graphql_api', path: '../..'
+      gem 'graphiql-rails'
+    RUBY
+
+    system! 'bundle install'
+  end
 end

--- a/solidus_graphql_api.gemspec
+++ b/solidus_graphql_api.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   #s.add_development_dependency 'rubocop-rails', '1.4.0'
   #s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
Adding Gemfile to the test app allows us to manage test app dependencies without having them in the gemspec (see #30)