### PR TITLE
JWT authentication

### DIFF
--- a/app/controllers/concerns/spree/graphql/jwt_authentication.rb
+++ b/app/controllers/concerns/spree/graphql/jwt_authentication.rb
@@ -1,0 +1,43 @@
+module Spree
+  module Graphql
+    module JwtAuthentication
+      extend ActiveSupport::Concern
+
+      included do
+        attr_reader :json_web_token
+
+        before_action :load_json_web_token
+        before_action :load_user
+        before_action :check_api_key_validity
+      end
+
+      private
+
+      def load_json_web_token
+        @json_web_token = SolidusJwt.decode(api_key).first
+      rescue JWT::DecodeError
+      end
+
+      def load_user
+        user_id = json_web_token.try(:[], 'id')
+        @current_graphql_user = Spree.user_class.find_by(id: user_id) if user_id
+      end
+
+      def check_api_key_validity
+        if api_key && !current_graphql_user
+          head :unauthorized
+        end
+      end
+
+      def api_key
+        bearer_token
+      end
+
+      def bearer_token
+        pattern = /^Bearer /
+        header = request.headers['Authorization']
+        header.gsub(pattern, '') if header.present? && header.match(pattern)
+      end
+    end
+  end
+end

--- a/app/models/spree/graphql_configuration.rb
+++ b/app/models/spree/graphql_configuration.rb
@@ -1,0 +1,5 @@
+module Spree
+  class GraphqlConfiguration < Preferences::Configuration
+    preference :requires_authentication, :boolean, default: true
+  end
+end

--- a/lib/solidus_graphql_api/engine.rb
+++ b/lib/solidus_graphql_api/engine.rb
@@ -5,6 +5,10 @@ module Spree
       isolate_namespace Spree
       engine_name 'solidus_graphql_api'
 
+      initializer 'spree.graphql.environment', before: :load_config_initializers do |app|
+        Spree::GraphQL::Config = Spree::GraphqlConfiguration.new
+      end
+
       # use rspec for tests
       config.generators do |g|
         g.test_framework :rspec

--- a/lib/solidus_graphql_api/graphql/all.rb
+++ b/lib/solidus_graphql_api/graphql/all.rb
@@ -1,6 +1,7 @@
 require 'graphql'
 require 'ostruct'
 require 'action_view'
+require 'solidus_jwt'
 
 module Spree
   module GraphQL

--- a/solidus_graphql_api.gemspec
+++ b/solidus_graphql_api.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus_core', '>= 2.7.0'
   s.add_dependency 'graphql', '~> 1.9.3'
+  s.add_dependency 'solidus_jwt', '>= 0.0.1'
 
   s.add_development_dependency 'database_cleaner'
   #s.add_development_dependency 'byebug'

--- a/spec/controllers/spree/graphql_controller_spec.rb
+++ b/spec/controllers/spree/graphql_controller_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Spree::GraphqlController do
+  describe '#execute' do
+    let(:action) { post :execute, {} }
+    let(:headers) { {} }
+
+    subject { action }
+
+    before { @request.headers.merge! headers }
+
+    context 'when the authentication is required' do
+      before { Spree::GraphQL::Config.set(requires_authentication: false) }
+
+      context 'when the API key is invalid' do
+        let(:headers) { { 'Authorization' => 'Bearer INVALID_API_KEY' } }
+
+        it { is_expected.to have_http_status :unauthorized }
+
+        it 'does not execute any GraphQL query' do
+          expect(Spree::GraphQL::Schema::Schema).not_to receive(:execute)
+          subject
+        end
+      end
+
+      context 'when the API key is missing' do
+        it { is_expected.to have_http_status :ok }
+
+        it 'does not set any user as the current user in the GraphQL context' do
+          expect(Spree::GraphQL::Schema::Schema).to receive(:execute).with(
+            anything,
+            a_hash_including(
+              context: a_hash_including(
+                current_user: nil
+              )
+            )
+          )
+          subject
+        end
+      end
+
+      context 'when the API key is valid' do
+        let(:user) { create :user }
+        let(:headers) { { 'Authorization' => "Bearer #{user.generate_jwt_token}" } }
+
+        it { is_expected.to have_http_status :ok }
+
+        it 'sets the user matching the API key as the current user in the GraphQL context' do
+          expect(Spree::GraphQL::Schema::Schema).to receive(:execute).with(
+            anything,
+            a_hash_including(
+              context: a_hash_including(
+                current_user: user
+              )
+            )
+          )
+          subject
+        end
+      end
+    end
+
+    context 'when the authentication is not required' do
+      before { Spree::GraphQL::Config.set(requires_authentication: true) }
+
+      context 'when the API key is invalid' do
+        let(:headers) { { 'Authorization' => 'Bearer INVALID_API_KEY' } }
+
+        it { is_expected.to have_http_status :unauthorized }
+
+        it 'does not execute any GraphQL query' do
+          expect(Spree::GraphQL::Schema::Schema).not_to receive(:execute)
+          subject
+        end
+      end
+
+      context 'when the API key is missing' do
+        it { is_expected.to have_http_status :unauthorized }
+
+        it 'does not execute any GraphQL query' do
+          expect(Spree::GraphQL::Schema::Schema).not_to receive(:execute)
+          subject
+        end
+      end
+
+      context 'when the API key is valid' do
+        let(:user) { create :user }
+        let(:headers) { { 'Authorization' => "Bearer #{user.generate_jwt_token}" } }
+
+        it { is_expected.to have_http_status :ok }
+
+        it 'sets the user matching the API key as the current user in the GraphQL context' do
+          expect(Spree::GraphQL::Schema::Schema).to receive(:execute).with(
+            anything,
+            a_hash_including(
+              context: a_hash_including(
+                current_user: user
+              )
+            )
+          )
+          subject
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related to #14. It uses `solidus_jwt` gem in order to authenticate users via JSON Web Token. Authentication errors are reported to the client using the `401 Unauthorized` HTTP status.

It comes with a RSpec configuration refactoring, made because I was having troubles testing `Spree::GraphqlController`. If needed it could go into another PR.