### PR TITLE
Allow people to set a local .Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /Gemfile.lock
+/.Gemfile
 /spec/dummy
 /spec/samples.txt

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gem 'solidus_auth_devise'
 #gem 'deface'
 
 gemspec
+
+local_gemfile = File.expand_path('.Gemfile', __dir__)
+instance_eval File.read local_gemfile if File.exist? local_gemfile


### PR DESCRIPTION
In this way depencencies required for regular development can be specified without mess with `Gemfile`.